### PR TITLE
Fixed HTML embed example

### DIFF
--- a/src/inform7/extensions/Vorple Core.i7x
+++ b/src/inform7/extensions/Vorple Core.i7x
@@ -297,7 +297,7 @@ The previous example generates this markup:
 The elements are always created empty and with a closing tag. Content can be added to them with these phrases:
 
 	place "An exciting story" in the element "title";
-	display "Story so far:" in a "h2" element with class "subtitle";
+	display "Story so far:" in element "h2" with class "subtitle";
 	display "Anonymous Adventurer" in an element with class "name";
 
 The "place" phrase will use an existing element(s) with the given class, overwriting previous content. The "display" phrases create new elements. The default element, if not otherwise specified, is span.


### PR DESCRIPTION
Good day!

The documentation for the Vorple Core extension contained an incorrect usage example of the "display" phrase. Now fixed.

Please review.
